### PR TITLE
Update configuration and deployment documentation

### DIFF
--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -20,9 +20,9 @@ The following are the detailed configurations for the API server. You can inject
 | Env | Description | Default Value |
 | --- | --- | --- |
 | OPENAI_API_KEY | API key for OpenAI (or any other compatible provider), used for LLM inference and embeddings | (not set) |
-| OPENAI_BASE_URL | Base URL for OpenAI compatible provider | `https://api.openai.com` |
+| OPENAI_BASE_URL | Base URL for OpenAI compatible provider | (not set) |
 | OPENROUTER_API_KEY | [OpenRouter](https://openrouter.ai/) API key, used for LLM inference | (not set) |
-| JINA_API_KEY | [Jina](https://jina.ai/) API key, used for embeddings | (not set) |
+| JINA_API_KEY | [Jina](https://jina.ai/) API key, used for embeddings and weblink parsing | (not set) |
 | FIREWORKS_API_KEY | [Fireworks](https://fireworks.ai/) API key, used for embedding | (not set) |
 | SERPER_API_KEY | [Serper](https://serper.dev/) API key, used for online search | (not set) |
 | MARKER_API_KEY | [Marker](https://www.datalab.to/) API key, used for PDF parsing | (not set) |

--- a/guide/self-deploy/index.md
+++ b/guide/self-deploy/index.md
@@ -45,7 +45,7 @@ Notes on must-set environment variables:
 - **Envs for Web Search**:
   - `SERPER_API_KEY`: [Serper](https://serper.dev/) API key
 
-::: tip
+::: info
 A comprehensive list of all the configuration options is available in the [Configuration](../configuration.md).
 :::
 
@@ -54,6 +54,10 @@ A comprehensive list of all the configuration options is available in the [Confi
 ```bash
 docker compose up -d
 ```
+
+::: tip For passionate users
+By default, the docker compose file will pull the `latest` image, which is the latest stable version. If you want to use the up-to-date version synced with the Refly Cloud, you can replace image tag `latest` with `nightly` in the `docker-compose.yml` file.
+:::
 
 You can run `docker ps` to check the status of the containers. The expected status for each container should be `Up` and `healthy`. An example output is shown below:
 
@@ -84,7 +88,7 @@ Models are configured via the `refly.model_infos` table within the `refly_db` Po
 
 | Provider | `OPENAI_BASE_URL` | SQL File |
 | -------- | ----------------- | -------- |
-| [OpenAI](https://platform.openai.com/) | `https://api.openai.com` | [openai.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openai.sql) |
+| [OpenAI](https://platform.openai.com/) | (empty) | [openai.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openai.sql) |
 | [OpenRouter](https://openrouter.ai/) | `https://openrouter.ai/api/v1` | [openrouter.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openrouter.sql) |
 | [DeepSeek](https://platform.deepseek.com/) | `https://api.deepseek.com` | [deepseek.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/deepseek.sql) |
 | [Ollama](https://ollama.com/) | `http://host.docker.internal:11434/v1` | [ollama.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/ollama.sql) |

--- a/zh/guide/configuration.md
+++ b/zh/guide/configuration.md
@@ -20,9 +20,9 @@
 | 环境变量 | 说明 | 默认值 |
 | --- | --- | --- |
 | OPENAI_API_KEY | [OpenAI](https://openai.com/) 或其他兼容供应方的 API 密钥，用于 LLM 推理和嵌入 | (未设置) |
-| OPENAI_BASE_URL | OpenAI 兼容供应方的基础 URL，用于 LLM 推理和嵌入 | `https://api.openai.com` |
+| OPENAI_BASE_URL | OpenAI 兼容供应方的基础 URL，用于 LLM 推理和嵌入 | (未设置) |
 | OPENROUTER_API_KEY | [OpenRouter](https://openrouter.ai/) API 密钥，用于 LLM 推理 | (未设置) |
-| JINA_API_KEY | [Jina](https://jina.ai/) API 密钥，用于嵌入 | (未设置) |
+| JINA_API_KEY | [Jina](https://jina.ai/) API 密钥，用于嵌入和网页解析 | (未设置) |
 | FIREWORKS_API_KEY | [Fireworks](https://fireworks.ai/) API 密钥，用于嵌入 | (未设置) |
 | SERPER_API_KEY | [Serper](https://serper.dev/) API 密钥，用于在线搜索 | (未设置) |
 | MARKER_API_KEY | [Marker](https://www.datalab.to/) API 密钥，用于 PDF 解析 | (未设置) |

--- a/zh/guide/self-deploy/index.md
+++ b/zh/guide/self-deploy/index.md
@@ -45,7 +45,7 @@ cp ../../apps/api/.env.example .env
 - **网络搜索相关环境变量**：
   - `SERPER_API_KEY`：[Serper](https://serper.dev/) API 密钥
 
-::: tip
+::: info
 所有配置选项的完整列表可以在[配置指南](../configuration.md)中找到。
 :::
 
@@ -54,6 +54,10 @@ cp ../../apps/api/.env.example .env
 ```bash
 docker compose up -d
 ```
+
+::: tip 对于热情的用户
+默认情况下，docker compose 文件会拉取 `latest` 镜像，这是最新的稳定版本。如果您想使用与 Refly Cloud 同步的最新开发版本，可以在 `docker-compose.yml` 文件中将镜像标签 `latest` 替换为 `nightly`。
+:::
 
 您可以运行 `docker ps` 来检查容器的状态。每个容器的预期状态应该是 `Up` 和 `healthy`。以下是示例输出：
 
@@ -82,9 +86,9 @@ e7b398dbd02b   postgres:16-alpine                         "docker-entrypoint.s�
 
 模型配置通过 `refly_db` PostgreSQL 数据库中的 `refly.model_infos` 表进行管理。我们为一些常见的提供商准备了推荐的模型 SQL 文件：
 
-| 提供商 | `OPENAI_BASE_URL` | SQL 文件
+| 提供商 | `OPENAI_BASE_URL` | SQL 文件 |
 | -------- | ----------------- | -------- |
-| [OpenAI](https://platform.openai.com/) | `https://api.openai.com` | [openai.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openai.sql) |
+| [OpenAI](https://platform.openai.com/) | (空) | [openai.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openai.sql) |
 | [OpenRouter](https://openrouter.ai/) | `https://openrouter.ai/api/v1` | [openrouter.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/openrouter.sql) |
 | [DeepSeek](https://platform.deepseek.com/) | `https://api.deepseek.com` | [deepseek.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/deepseek.sql) |
 | [Ollama](https://ollama.com/) | `http://host.docker.internal:11434/v1` | [ollama.sql](https://github.com/refly-ai/refly/blob/main/deploy/model-providers/ollama.sql) |


### PR DESCRIPTION
- Remove default OpenAI base URL and update Jina API key description
- Change deployment guide tip style from `tip` to `info`
- Add nightly image tag usage tip for advanced users
- Update model provider table to reflect empty OpenAI base URL
- Synchronize changes across English and Chinese documentation